### PR TITLE
fix(build): Do not link u2mfn

### DIFF
--- a/gui-agent-qemu/Makefile.objs
+++ b/gui-agent-qemu/Makefile.objs
@@ -1,6 +1,6 @@
 common-obj-y += qubes-gui.o
 qubes-gui.o-cflags += $(QUBES_GUI_CFLAGS)
-qubes-gui.o-libs += $(shell pkg-config --libs vchan-xen) -lu2mfn
+qubes-gui.o-libs += $(shell pkg-config --libs vchan-xen)
 
 generated-files-y += $(QUBES_GUI_DIR)/gui-agent-qemu/qubes-keycode2scancode.c
 


### PR DESCRIPTION
https://github.com/QubesOS/qubes-core-vchan-xen/pull/14 removed u2mfn
lib and broken the `vmm-xen-stubdom-linux` build.

PS: Is there some automatic process building iso once a day or after any package
changes? I only noticed this because I frequently do builds from scratch.