### PR TITLE
Announce protocol version supported by the agent

### DIFF
--- a/gui-agent-qemu/qubes-gui.c
+++ b/gui-agent-qemu/qubes-gui.c
@@ -396,7 +396,7 @@ static void handle_keymap_notify(QubesGuiState * qs)
 
 static void send_protocol_version(QubesGuiState *qs)
 {
-    uint32_t version = QUBES_GUID_PROTOCOL_VERSION;
+    uint32_t version = QUBES_GUI_PROTOCOL_VERSION_STUBDOM;
     write_struct(qs->vchan, version);
 }
 


### PR DESCRIPTION
... not necessarily latest defined in the header.
It will become relevant with
https://github.com/QubesOS/qubes-gui-common/pull/16